### PR TITLE
外部コマンド発行を行わないlibgv-rubyを使用するよう変更

### DIFF
--- a/graphviz.rb
+++ b/graphviz.rb
@@ -9,6 +9,15 @@
 require 'digest/md5'
 require 'tempfile'
 require 'gv'
+require 'cgi'
+
+# hikiでは、dot_stringがCGI.escapeHTMLされてくるため、
+# dot言語でノードのつながりを表す「->」の「>」が「gt」などと変換されてしまう。
+# これを防ぐため、CGI.unescapeHTMLする。
+# なお、tdiaryでの動作を崩さないよう、hiki用ラップメソッドとして作成した。
+def graphviz_hiki(dot_string, option = {:format => :jpg})
+    graphviz(CGI.unescapeHTML(dot_string), option)
+end
 
 def graphviz(dot_string, option = {:format => :jpg})
    # dot option

--- a/graphviz.rb
+++ b/graphviz.rb
@@ -8,6 +8,7 @@
 
 require 'digest/md5'
 require 'tempfile'
+require 'gv'
 
 def graphviz(dot_string, option = {:format => :jpg})
    # dot option
@@ -124,11 +125,9 @@ module ::Graphviz
             stdout   = Tempfile.new("#{digest}-stdout")
             stderr   = Tempfile.new("#{digest}-stderr")
             require_close = [dot_file, stdout, stderr]
-            cmd = "#{g_conf.dot_path} -T#{option[:format].to_s} #{dot_file.path} -o #{img_path} 2> #{stderr.path} > #{stdout.path}"
-            `#{cmd}`
-#            `#{g_conf.dot_path} -T#{option[:format].to_s} #{dot_file.path} -o #{img_path} 2> #{stderr.path} > #{stdout.path}`
-            
-            if $?.to_i / 256 != 0
+            gh = Gv.readstring(@dot_string)
+            Gv.layout(gh,"dot")
+            unless Gv.render(gh, option[:format].to_s, img_path)
                msg = "<p>The Command:<br>"    \
                      "<p>#{cmd}<br>"    \
                      "<b>exit_code=</b>#{$?.to_i / 256}<br>" \
@@ -145,6 +144,7 @@ module ::Graphviz
                   tmp.unlink
                end
             end
+            Gv.rm(gh)
          end
          img_file
       end


### PR DESCRIPTION
tDiary3.0.xで、外部コマンド発行ができなくなりした。これにより、外部コマンドにより画像生成を行う、graphviz.rbが使用不能となっています。

このパッチでは、外部コマンド発行を行わないlibgv-ruby(Ruby bindings for graphviz)を使用するよう変更しました。graphviz 2.26.3、 libgv-ruby 2.26.3、Ruby 1.8.7-p249、tDiary3.0.2安定版にて稼動を確認しています。

パッチの取込をご検討ください。
